### PR TITLE
Use a sane version of ring/ring-core

### DIFF
--- a/resources/io/github/nextjournal/garden_template/build/deps.tmpl
+++ b/resources/io/github/nextjournal/garden_template/build/deps.tmpl
@@ -1,5 +1,5 @@
 {:deps {http-kit/http-kit {:mvn/version "2.8.0-SNAPSHOT"}
-        ring/ring-core {:mvn/version "2.0.0-alpha1"}
+        ring/ring-core {:mvn/version "1.12.1"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}
         io.github.nextjournal/garden-cron {:git/sha "23d5af087f2c76cc884273883b18d30cb4fa4997"}
         io.github.nextjournal/garden-id {:git/sha "06b67b5cf77d4d0573975f6cbe9bb6d69cce60eb"}


### PR DESCRIPTION
The 2.0.0-alpha1 branch/release of ring/ring-core is very old, over 4 years old and apparently abandoned. The current release that should be used is 1.12.1